### PR TITLE
Fix mismatched preference name causing error message when changing default ports

### DIFF
--- a/stomp.lua
+++ b/stomp.lua
@@ -47,7 +47,7 @@ p_stomp.prefs["tcp_port"] = Pref.uint(
     "TCP Port for STOMP standards-compliant communication (0 to disable)"
 )
 
-p_stomp.prefs["tls_port"] = Pref.uint(
+p_stomp.prefs["ssl_port"] = Pref.uint(
     "STOMP-over-SSL TCP Port",
     settings.TCP_PORT,
     "TCP Port for STOMP over SSL (0 to disable)"


### PR DESCRIPTION
The following error appears when changing the default ports in the preferences window:

Lua: Error during execution of prefs apply callback:
 C:\Program Files\Wireshark\plugins\4.2\stomp\stomp.lua:204: bad argument #2 to '__index' (Prefs__index: no preference named like this)

It happens because the preference for SSL/TLS port is called "tls_port" in line 50, while it is referred to as "ssl_port" in line 204.

The fix makes the preference names consistent.